### PR TITLE
Implement basic FastAPI webhook server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # ServidorGame
+
+This repository contains a simple FastAPI server used as the central controller for the *ClienteGame* Telegram bot. It exposes a single endpoint to handle incoming webhook events.
+
+## Usage
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Run the server:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+The server listens on `/user/webhook` for POST requests with JSON payloads describing Telegram bot messages.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,2 @@
+__all__ = ["app"]
+from .main import app

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,28 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+from typing import Optional, Dict
+import logging
+from datetime import datetime
+
+logging.basicConfig(level=logging.INFO)
+
+app = FastAPI(title="ServidorGame")
+
+class WebhookPayload(BaseModel):
+    user_id: int
+    message_type: str
+    message_data: Optional[str] = None
+    timestamp: Optional[float] = Field(default_factory=lambda: datetime.utcnow().timestamp())
+    metadata: Optional[Dict] = None
+
+@app.post("/user/webhook")
+async def user_webhook(payload: WebhookPayload):
+    logging.info("Received webhook: %s", payload.json())
+
+    # Placeholder logic - in the future implement bot logic here
+    response = {"action": "reply", "data": {"text": "Message received"}}
+    return response
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.110.0
+uvicorn==0.27.1
+pydantic==2.6.3


### PR DESCRIPTION
## Summary
- implement FastAPI server with `/user/webhook` endpoint
- log incoming requests and return simple JSON action
- document project usage
- add dependency list

## Testing
- `python -m py_compile app/main.py`
- `pip install -r requirements.txt`
- `python -m uvicorn app.main:app --port 8000 --host 127.0.0.1 --log-level warning &`
- `curl -s -X POST http://127.0.0.1:8000/user/webhook -H "Content-Type: application/json" -d '{"user_id":1,"message_type":"text","message_data":"hello"}'`


------
https://chatgpt.com/codex/tasks/task_e_6851d0e18fa88329af4eddbcfe2b097c