### PR TITLE
Add user role validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,11 @@ uvicorn app.main:app --reload
 ```
 
 The server listens on `/user/webhook` for POST requests with JSON payloads describing Telegram bot messages.
+
+### Environment variables
+
+The following variables control access level detection:
+
+- `TELEGRAM_BOT_TOKEN` - token of the bot used for API calls.
+- `TELEGRAM_VIP_CHANNEL_ID` - channel ID checked for VIP membership.
+- `TELEGRAM_ADMIN_ID` - Telegram user ID that should be treated as administrator.

--- a/app/main.py
+++ b/app/main.py
@@ -3,10 +3,16 @@ from pydantic import BaseModel, Field
 from typing import Optional, Dict
 import logging
 from datetime import datetime
+import os
+import httpx
 
 logging.basicConfig(level=logging.INFO)
 
 app = FastAPI(title="ServidorGame")
+
+TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
+TELEGRAM_VIP_CHANNEL_ID = os.getenv("TELEGRAM_VIP_CHANNEL_ID")
+TELEGRAM_ADMIN_ID = os.getenv("TELEGRAM_ADMIN_ID")
 
 class WebhookPayload(BaseModel):
     user_id: int
@@ -14,6 +20,38 @@ class WebhookPayload(BaseModel):
     message_data: Optional[str] = None
     timestamp: Optional[float] = Field(default_factory=lambda: datetime.utcnow().timestamp())
     metadata: Optional[Dict] = None
+
+
+async def is_user_vip(user_id: int) -> bool:
+    """Check if the user is part of the VIP channel."""
+    if not TELEGRAM_BOT_TOKEN or not TELEGRAM_VIP_CHANNEL_ID:
+        return False
+
+    url = f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/getChatMember"
+    params = {"chat_id": TELEGRAM_VIP_CHANNEL_ID, "user_id": user_id}
+
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(url, params=params, timeout=5)
+            if resp.status_code == 200:
+                data = resp.json()
+                if data.get("ok") and data.get("result"):
+                    status = data["result"].get("status")
+                    if status in {"member", "administrator", "creator"}:
+                        return True
+    except Exception as exc:  # pragma: no cover - network errors ignored in tests
+        logging.warning("VIP check failed: %s", exc)
+
+    return False
+
+
+async def get_user_role(user_id: int) -> str:
+    """Return the role for the given user id."""
+    if TELEGRAM_ADMIN_ID and str(user_id) == TELEGRAM_ADMIN_ID:
+        return "admin"
+    if await is_user_vip(user_id):
+        return "vip"
+    return "free"
 
 
 async def handle_start(payload: WebhookPayload):
@@ -58,22 +96,31 @@ async def user_webhook(payload: WebhookPayload):
     """Route incoming messages to the appropriate handler."""
     logging.info("Received webhook: %s", payload.json())
 
+    user_role = await get_user_role(payload.user_id)
+
+    response = None
+
     if payload.message_type == "text":
         if payload.message_data and payload.message_data.startswith("/start"):
-            return await handle_start(payload)
-        return await handle_text_input(payload)
+            response = await handle_start(payload)
+        else:
+            response = await handle_text_input(payload)
 
-    if payload.message_type == "callback_query":
-        return await handle_callback_query(payload)
+    elif payload.message_type == "callback_query":
+        response = await handle_callback_query(payload)
 
-    if payload.message_type == "button_click":
-        return await handle_button_click(payload)
+    elif payload.message_type == "button_click":
+        response = await handle_button_click(payload)
 
-    if payload.message_type == "menu_selection":
-        return await handle_menu_selection(payload)
+    elif payload.message_type == "menu_selection":
+        response = await handle_menu_selection(payload)
+    else:
+        logging.warning("Unknown message type: %s", payload.message_type)
+        raise HTTPException(status_code=400, detail="Unknown message type")
 
-    logging.warning("Unknown message type: %s", payload.message_type)
-    raise HTTPException(status_code=400, detail="Unknown message type")
+    if isinstance(response, dict):
+        response["user_role"] = user_role
+    return response
 
 if __name__ == "__main__":
     import uvicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.110.0
 uvicorn==0.27.1
 pydantic==2.6.3
+httpx==0.27.0


### PR DESCRIPTION
## Summary
- detect user roles for webhook requests
- check membership with Telegram's `getChatMember`
- include `user_role` in webhook responses
- document new environment variables
- add `httpx` dependency

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6851d30072bc8329bfa80f3363245611