### PR TITLE
Add internal routing for webhook messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 FastAPI server for handling messages from the Telegram bot ClienteGame.
 
+The `/user/webhook` endpoint now routes incoming messages to internal
+placeholder handlers based on the `message_type` field. Supported types are:
+
+* `/start` command
+* `callback_query`
+* `text`
+* `button_click`
+* `menu_selection`
+
 ## Running
 
 Install dependencies and start the server:

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Callable
 import logging
 
 app = FastAPI(title="ServidorGame")
@@ -21,8 +21,56 @@ class WebhookResponse(BaseModel):
     action: str
     data: Optional[Dict[str, Any]] = None
 
+
+def handle_start(payload: WebhookRequest) -> WebhookResponse:
+    """Placeholder handler for /start command."""
+    logger.info(f"Handling /start for user {payload.user_id}")
+    return WebhookResponse(action="send_message", data={"text": "Welcome!"})
+
+
+def handle_callback_query(payload: WebhookRequest) -> WebhookResponse:
+    """Placeholder handler for callback queries."""
+    logger.info(f"Handling callback query: {payload.message_data}")
+    return WebhookResponse(action="answer_callback", data={"text": "Callback received"})
+
+
+def handle_text_input(payload: WebhookRequest) -> WebhookResponse:
+    """Placeholder handler for text inputs."""
+    logger.info(f"Handling text input: {payload.message_data}")
+    return WebhookResponse(action="reply", data={"text": "Text received"})
+
+
+def handle_button_click(payload: WebhookRequest) -> WebhookResponse:
+    """Placeholder handler for button clicks."""
+    logger.info(f"Handling button click: {payload.message_data}")
+    return WebhookResponse(action="reply", data={"text": "Button clicked"})
+
+
+def handle_menu_selection(payload: WebhookRequest) -> WebhookResponse:
+    """Placeholder handler for menu selections."""
+    logger.info(f"Handling menu selection: {payload.message_data}")
+    return WebhookResponse(action="reply", data={"text": "Menu option chosen"})
+
+HANDLERS: Dict[str, Callable[[WebhookRequest], WebhookResponse]] = {
+    "callback_query": handle_callback_query,
+    "text": handle_text_input,
+    "button_click": handle_button_click,
+    "menu_selection": handle_menu_selection,
+}
+
+
 @app.post("/user/webhook", response_model=WebhookResponse)
 async def user_webhook(payload: WebhookRequest):
+    """Route incoming webhook payloads to the appropriate handler."""
     logger.info(f"Received payload: {payload.json()}")
-    return WebhookResponse(action="reply", data={"text": "Message received"})
+
+    if payload.message_type == "command" and payload.message_data == "/start":
+        return handle_start(payload)
+
+    handler = HANDLERS.get(payload.message_type)
+    if not handler:
+        logger.error(f"Unhandled message type: {payload.message_type}")
+        raise HTTPException(status_code=400, detail="Unknown message type")
+
+    return handler(payload)
 


### PR DESCRIPTION
## Summary
- route `/user/webhook` messages based on `message_type`
- add placeholder handlers for `/start`, callback queries, text, button clicks, and menu selections
- document supported message types in the README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile main.py`
- `uvicorn main:app --port 8000 --log-level info` *(server started then stopped)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6851d6e85db4832992a18140cbb6cc85